### PR TITLE
feat(send_mail): attachments + bcc support (Phase D)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules/
+build/
+.git/
+.gitignore
+.dockerignore
+.DS_Store
+*.log
+npm-debug.log*
+.env*
+.vscode/
+.idea/
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.4-pereneo.1] - 2026-05-01
+
+### 🔧 BL-47 — MCP HTTP spec §3 conformance fix
+
+Server now returns HTTP 404 (per MCP HTTP spec 2025-03-26 §3) when receiving
+requests with an unknown `Mcp-Session-Id` header (typical case: pod restart /
+cold start = in-memory `transports` map lost). Client receiving 404 must
+re-initialize without `Mcp-Session-Id` header (spec §4).
+
+Before this patch, server silently created a fresh empty transport on unknown
+session id, causing the next `tools/call` to return JSON-RPC
+`Server not initialized` with no recovery path — blocking long-running clients
+after pod recycling.
+
+Affects HTTP transport added in 0.6.4-pereneo.0 only. Stdio transport unaffected.
+
+Files changed: `src/index.ts` (POST /mcp + GET/DELETE handleSession).
+
+## [0.6.4-pereneo.0] - 2026-04-28 to 2026-04-29
+
+### 🚀 Streamable HTTP transport for Azure Container Apps
+
+Pereneo fork of `@pinkpixel/mem0-mcp` 0.6.4 adding Streamable HTTP server
+transport with OAuth 2.0 Resource Server pattern, suitable for deployment as
+Azure Container App.
+
+- **J1.0 (28/04/2026)** — Added Streamable HTTP transport (`StreamableHTTPServerTransport`)
+- **J4.0 (29/04/2026)** — Added OAuth 2.0 Resource Server (MCP authorization spec 2025-11-25)
+- **J4 fix (29/04/2026)** — Advertise fully-qualified OAuth scope in protected-resource metadata
+- **J4 fix (29/04/2026)** — Accept both URI and GUID audience in JWT validation
+- **Misc** — Added .dockerignore for minimal build context
+
 ## [0.6.1] - 2025-05-28
 
 ### 🔧 **PATCH - Supabase Configuration Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.4-pereneo.2] - 2026-06-09
+
+### ✨ send_mail Phase D — attachments + bcc
+
+Le tool `send_mail` accepte désormais des pièces jointes et des destinataires en
+copie cachée, en plus de `to` et `cc` déjà supportés. Avant ce patch, le COMEX
+ne pouvait envoyer aucune PJ via Charli/Claude Desktop ni faire d'envoi multi-
+destinataires masqués.
+
+- **Schema** : ajout de `bcc: string[]` et `attachments: [{name, contentType, contentBytes}]`
+- **Validation** : chaque attachment requiert `name` + `contentType` + `contentBytes` (base64).
+  Plafond cumulé `SEND_MAIL_ATTACHMENT_BASE64_LIMIT = 3.5 MB` de base64 (≈ 2.6 MB de
+  fichier brut) pour rester sous le cap Graph sendMail ~4 MB. Au-delà, retour
+  `attachment_too_large` avec hint (pas d'`createUploadSession` implémenté).
+- **Payload Graph** : injection de `message.bccRecipients` et `message.attachments[]`
+  avec le `@odata.type` `#microsoft.graph.fileAttachment`.
+- **Audit log** : `recipientsCount` inclut désormais les BCC ; ajout du champ
+  `attachments` dans la ligne `[send_mail] sent`.
+- **Retour** : `attachmentsCount` ajouté à la réponse `ok: true`.
+
+Files changed : `src/index.ts`.
+
 ## [0.6.4-pereneo.1] - 2026-05-01
 
 ### 🔧 BL-47 — MCP HTTP spec §3 conformance fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.12.0",
         "express": "^4.18.0",
+        "jose": "^6.2.3",
         "mem0ai": "^2.1.27"
       },
       "bin": {
@@ -2452,6 +2453,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tiktoken": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mem0-mcp-pereneo",
-  "version": "0.6.4-pereneo.0",
+  "version": "0.6.4-pereneo.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mem0-mcp-pereneo",
-      "version": "0.6.4-pereneo.0",
+      "version": "0.6.4-pereneo.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.12.0",
         "express": "^4.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
-  "name": "@pinkpixel/mem0-mcp",
-  "version": "0.6.4",
+  "name": "mem0-mcp-pereneo",
+  "version": "0.6.4-pereneo.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@pinkpixel/mem0-mcp",
-      "version": "0.6.4",
+      "name": "mem0-mcp-pereneo",
+      "version": "0.6.4-pereneo.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.12.0",
+        "express": "^4.18.0",
         "mem0ai": "^2.1.27"
       },
       "bin": {
         "mem0-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@types/express": "^4.17.0",
         "@types/node": "^22.15.23",
         "typescript": "^5.8.3"
       }
@@ -198,6 +200,252 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@qdrant/js-client-rest": {
@@ -390,6 +638,60 @@
         "@supabase/storage-js": "2.7.1"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -427,6 +729,13 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.23",
@@ -466,12 +775,59 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sqlite3": {
       "version": "3.1.11",
@@ -537,13 +893,13 @@
       }
     },
     "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -599,6 +955,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -702,23 +1064,69 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/braces": {
@@ -949,9 +1357,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -979,13 +1387,10 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1025,9 +1430,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1093,6 +1498,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -1310,41 +1725,45 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1365,6 +1784,21 @@
       "peerDependencies": {
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -1406,21 +1840,37 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -1464,27 +1914,6 @@
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
     },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
@@ -1508,12 +1937,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs-constants": {
@@ -1801,19 +2230,23 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -1840,15 +2273,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -2119,12 +2556,12 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/mem0ai": {
@@ -2173,15 +2610,21 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -2198,22 +2641,34 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.54.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2313,9 +2768,9 @@
       "peer": true
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2596,13 +3051,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.11.3",
@@ -2928,9 +3380,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2952,18 +3404,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -3048,6 +3500,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -3098,40 +3560,57 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.8.0"
       }
     },
-    "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -3346,9 +3825,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3501,14 +3980,13 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
       },
       "engines": {
         "node": ">= 0.6"
@@ -3567,6 +4045,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.12.0",
     "express": "^4.18.0",
+    "jose": "^6.2.3",
     "mem0ai": "^2.1.27"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@pinkpixel/mem0-mcp",
-  "version": "0.6.4",
-  "description": "A Model Context Protocol server that can store and retrieve memories for LLM context control",
+  "name": "mem0-mcp-pereneo",
+  "version": "0.6.4-pereneo.0",
+  "description": "Pereneo fork of @pinkpixel/mem0-mcp — adds Streamable HTTP transport for Azure Container Apps deployment",
   "private": false,
   "type": "module",
   "bin": {
@@ -19,9 +19,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.12.0",
+    "express": "^4.18.0",
     "mem0ai": "^2.1.27"
   },
   "devDependencies": {
+    "@types/express": "^4.17.0",
     "@types/node": "^22.15.23",
     "typescript": "^5.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0-mcp-pereneo",
-  "version": "0.6.4-pereneo.0",
+  "version": "0.6.4-pereneo.1",
   "description": "Pereneo fork of @pinkpixel/mem0-mcp — adds Streamable HTTP transport for Azure Container Apps deployment",
   "private": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0-mcp-pereneo",
-  "version": "0.6.4-pereneo.1",
+  "version": "0.6.4-pereneo.2",
   "description": "Pereneo fork of @pinkpixel/mem0-mcp — adds Streamable HTTP transport for Azure Container Apps deployment",
   "private": false,
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
 import type { Memory as MemoryType } from "mem0ai/oss";
 import express from "express";
 import { randomUUID } from "node:crypto";
+import { createRemoteJWKSet, jwtVerify } from "jose";
 
 // Load Mem0 library after configuring environment to avoid unwanted telemetry
 let Memory: typeof import("mem0ai/oss").Memory;
@@ -939,12 +940,65 @@ class Mem0MCPServer {
     }
 
     const port = parseInt(process.env.PORT || '8080', 10);
+
+    // OAuth 2.0 Resource Server configuration (MCP authorization spec 2025-11-25 / RFC 9728 / RFC 8707)
+    const tenantId = process.env.ENTRA_TENANT_ID;
+    const audience = process.env.ENTRA_AUDIENCE;
+    const resourceUrl = process.env.RESOURCE_URL;
+    if (!tenantId || !audience || !resourceUrl) {
+      process.stderr.write('FATAL: ENTRA_TENANT_ID, ENTRA_AUDIENCE, and RESOURCE_URL env vars are required in HTTP mode.\n');
+      process.exit(1);
+    }
+    const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
+    const jwksUri = `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
+    const JWKS = createRemoteJWKSet(new URL(jwksUri), {
+      cacheMaxAge: 3600 * 1000,
+      cooldownDuration: 30 * 1000,
+    });
+    const protectedResourceMetadata = {
+      resource: resourceUrl,
+      authorization_servers: [issuer],
+      scopes_supported: ['mcp.access'],
+      bearer_methods_supported: ['header'],
+      resource_documentation: 'https://github.com/GroupePerenne/mem0-mcp-pereneo',
+    };
+    const metadataUrl = new URL('/.well-known/oauth-protected-resource', resourceUrl).toString();
+    const wwwAuthHeader = (errorCode?: string, description?: string) => {
+      let header = `Bearer resource_metadata="${metadataUrl}"`;
+      if (errorCode) header += `, error="${errorCode}"`;
+      if (description) header += `, error_description="${description.replace(/"/g, "'")}"`;
+      return header;
+    };
+    const jwtMiddleware: express.RequestHandler = async (req, res, next) => {
+      const authHeader = req.header('authorization') || req.header('Authorization');
+      if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+        res.set('WWW-Authenticate', wwwAuthHeader());
+        res.status(401).json({ error: 'unauthorized', error_description: 'Bearer token required' });
+        return;
+      }
+      const token = authHeader.slice(7).trim();
+      try {
+        await jwtVerify(token, JWKS, { issuer, audience, algorithms: ['RS256'] });
+        next();
+      } catch (err: any) {
+        const description = err?.code || err?.message || 'invalid_token';
+        res.set('WWW-Authenticate', wwwAuthHeader('invalid_token', description));
+        res.status(401).json({ error: 'invalid_token', error_description: description });
+      }
+    };
+
     const app = express();
     app.use(express.json({ limit: '4mb' }));
 
     app.get('/health', (_req, res) => {
       res.status(200).json({ status: 'ok', ready: this.isReady });
     });
+
+    app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+      res.status(200).json(protectedResourceMetadata);
+    });
+
+    app.use('/mcp', jwtMiddleware);
 
     const transports: Record<string, StreamableHTTPServerTransport> = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -958,7 +958,9 @@ class Mem0MCPServer {
     const protectedResourceMetadata = {
       resource: resourceUrl,
       authorization_servers: [issuer],
-      scopes_supported: ['mcp.access'],
+      // Entra v2 requires fully-qualified scope (api://<resource>/<scope>) for cross-resource resolution.
+      // Short scope ("mcp.access") falls back to Microsoft Graph and triggers AADSTS650053.
+      scopes_supported: [`${audience}/mcp.access`],
       bearer_methods_supported: ['header'],
       resource_documentation: 'https://github.com/GroupePerenne/mem0-mcp-pereneo',
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1001,6 +1001,28 @@ class Mem0MCPServer {
       res.status(200).json({ status: 'ok', ready: this.isReady });
     });
 
+    app.get('/health/deep', async (_req, res) => {
+      if (!this.isReady) {
+        res.status(503).json({ status: 'not_ready', ready: false });
+        return;
+      }
+      const client = this.cloudClient || this.supabaseClient || this.localClient;
+      if (!client) {
+        res.status(503).json({ status: 'no_client', ready: false });
+        return;
+      }
+      const timeoutMs = Number(process.env.HEALTH_DEEP_TIMEOUT_MS || 3000);
+      try {
+        await Promise.race([
+          client.search('healthcheck-ping', { user_id: '_healthcheck_charli_deep', limit: 1 }),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('healthcheck_timeout')), timeoutMs))
+        ]);
+        res.status(200).json({ status: 'ok', ready: true });
+      } catch (err: any) {
+        res.status(503).json({ status: 'unhealthy', error: err?.message || 'unknown' });
+      }
+    });
+
     app.get('/.well-known/oauth-protected-resource', (_req, res) => {
       res.status(200).json(protectedResourceMetadata);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,17 @@
  * 1. Cloud mode: Uses Mem0's hosted API with MEM0_API_KEY
  * 2. Local mode: Uses in-memory storage with OPENAI_API_KEY for embeddings
  */
-// Complete console logging suppression for MCP protocol compatibility
-// This ensures no library logs interfere with the MCP communication protocol
-const noOp = () => {};
-console.log = noOp;
-console.error = noOp;
-console.warn = noOp;
-console.info = noOp;
-console.debug = noOp;
-console.trace = noOp;
+// Console suppression is required only for stdio MCP transport (logs would pollute the JSON-RPC channel).
+// HTTP transport (default for this Pereneo fork) keeps console enabled for Container App log capture.
+if (process.env.MCP_TRANSPORT === 'stdio') {
+  const noOp = () => {};
+  console.log = noOp;
+  console.error = noOp;
+  console.warn = noOp;
+  console.info = noOp;
+  console.debug = noOp;
+  console.trace = noOp;
+}
 
 // Environment variables to disable logging in various libraries
 process.env.DEBUG = '';
@@ -32,6 +34,7 @@ process.env.NO_COLOR = 'true';
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -39,6 +42,8 @@ import {
   ErrorCode,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { Memory as MemoryType } from "mem0ai/oss";
+import express from "express";
+import { randomUUID } from "node:crypto";
 
 // Load Mem0 library after configuring environment to avoid unwanted telemetry
 let Memory: typeof import("mem0ai/oss").Memory;
@@ -923,10 +928,61 @@ class Mem0MCPServer {
 
   /**
    * Starts the MCP server.
+   * Default: Streamable HTTP transport on PORT (default 8080), suitable for remote use behind a reverse proxy.
+   * Set MCP_TRANSPORT=stdio for legacy stdio mode (local Claude Desktop usage).
    */
   public async start(): Promise<void> {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    if (process.env.MCP_TRANSPORT === 'stdio') {
+      const transport = new StdioServerTransport();
+      await this.server.connect(transport);
+      return;
+    }
+
+    const port = parseInt(process.env.PORT || '8080', 10);
+    const app = express();
+    app.use(express.json({ limit: '4mb' }));
+
+    app.get('/health', (_req, res) => {
+      res.status(200).json({ status: 'ok', ready: this.isReady });
+    });
+
+    const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+    app.post('/mcp', async (req, res) => {
+      const sessionId = req.header('mcp-session-id');
+      let transport = sessionId ? transports[sessionId] : undefined;
+
+      if (!transport) {
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid) => {
+            transports[sid] = transport!;
+          },
+        });
+        transport.onclose = () => {
+          const sid = transport!.sessionId;
+          if (sid) delete transports[sid];
+        };
+        await this.server.connect(transport);
+      }
+
+      await transport.handleRequest(req, res, req.body);
+    });
+
+    const handleSession = async (req: express.Request, res: express.Response) => {
+      const sessionId = req.header('mcp-session-id');
+      if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+      }
+      await transports[sessionId].handleRequest(req, res);
+    };
+    app.get('/mcp', handleSession);
+    app.delete('/mcp', handleSession);
+
+    app.listen(port, '0.0.0.0', () => {
+      process.stderr.write(`mem0-mcp HTTP listening on :${port}\n`);
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1013,6 +1013,28 @@ class Mem0MCPServer {
       const sessionId = req.header('mcp-session-id');
       let transport = sessionId ? transports[sessionId] : undefined;
 
+      // SPEC MCP HTTP 2025-03-26 §3 (Session Management) :
+      // Si le client envoie un mcp-session-id que le serveur ne reconnaît pas
+      // (cas typique : pod restart / cold start = perte de la map transports
+      // tenue en mémoire process), le serveur DOIT répondre HTTP 404. Le client
+      // DOIT alors redo initialize sans Mcp-Session-Id (spec §4).
+      // Avant ce patch, le serveur créait un nouveau transport vide et lui
+      // transmettait directement la requête, ce qui résultait en
+      // "Server not initialized" côté client (BL-47).
+      if (sessionId && !transport) {
+        res.status(404).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: 'Session terminated',
+            data: { hint: 'Re-initialize without Mcp-Session-Id header' },
+          },
+          id: null,
+        });
+        return;
+      }
+
+      // Pas de mcp-session-id côté requête = nouveau handshake initialize attendu.
       if (!transport) {
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
@@ -1032,8 +1054,22 @@ class Mem0MCPServer {
 
     const handleSession = async (req: express.Request, res: express.Response) => {
       const sessionId = req.header('mcp-session-id');
-      if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+      // Header manquant = 400 Bad Request (input client invalide).
+      if (!sessionId) {
+        res.status(400).send('Missing Mcp-Session-Id header');
+        return;
+      }
+      // SPEC MCP HTTP §3 : session inconnue côté serveur → 404 (cf. POST handler).
+      if (!transports[sessionId]) {
+        res.status(404).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: 'Session terminated',
+            data: { hint: 'Re-initialize without Mcp-Session-Id header' },
+          },
+          id: null,
+        });
         return;
       }
       await transports[sessionId].handleRequest(req, res);

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,12 +943,17 @@ class Mem0MCPServer {
 
     // OAuth 2.0 Resource Server configuration (MCP authorization spec 2025-11-25 / RFC 9728 / RFC 8707)
     const tenantId = process.env.ENTRA_TENANT_ID;
-    const audience = process.env.ENTRA_AUDIENCE;
+    const audience = process.env.ENTRA_AUDIENCE;            // identifierUri (advertised in /.well-known)
+    const audienceGuid = process.env.ENTRA_AUDIENCE_GUID;   // appId GUID (Entra v2 emits this in aud claim)
     const resourceUrl = process.env.RESOURCE_URL;
     if (!tenantId || !audience || !resourceUrl) {
       process.stderr.write('FATAL: ENTRA_TENANT_ID, ENTRA_AUDIENCE, and RESOURCE_URL env vars are required in HTTP mode.\n');
       process.exit(1);
     }
+    // Per Microsoft docs (entra/identity-platform/access-token-claims-reference): v2 tokens carry
+    // aud = client ID GUID of the web API; v1 tokens carry aud = appID URI. We accept both for
+    // robustness across delegated and client_credentials flows.
+    const acceptedAudiences: string[] = [audience, audienceGuid].filter((x): x is string => !!x);
     const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
     const jwksUri = `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
     const JWKS = createRemoteJWKSet(new URL(jwksUri), {
@@ -980,7 +985,7 @@ class Mem0MCPServer {
       }
       const token = authHeader.slice(7).trim();
       try {
-        await jwtVerify(token, JWKS, { issuer, audience, algorithms: ['RS256'] });
+        await jwtVerify(token, JWKS, { issuer, audience: acceptedAudiences, algorithms: ['RS256'] });
         next();
       } catch (err: any) {
         const description = err?.code || err?.message || 'invalid_token';

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,43 @@ type Mem0Message = {
   content: string;
 };
 
+// Outbound Mailer Graph token cache (in-memory, TTL capped 60s) for send_mail tool.
+// Reset on process restart; Container App rotates the underlying secret externally.
+let _outboundTokenCache: { token: string; expiresAt: number } | null = null;
+
+async function getOutboundGraphToken(tenantId: string, clientId: string, clientSecret: string): Promise<string> {
+  const now = Date.now();
+  if (_outboundTokenCache && _outboundTokenCache.expiresAt > now + 5000) {
+    return _outboundTokenCache.token;
+  }
+  const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: "https://graph.microsoft.com/.default",
+    grant_type: "client_credentials",
+  }).toString();
+  const resp = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Graph token acquisition failed: ${resp.status} ${text.slice(0, 300)}`);
+  }
+  const json: any = await resp.json();
+  if (!json.access_token) {
+    throw new Error("Graph token acquisition: no access_token in response");
+  }
+  const expiresInSec = typeof json.expires_in === "number" ? json.expires_in : 3600;
+  _outboundTokenCache = {
+    token: json.access_token,
+    expiresAt: now + Math.min(expiresInSec * 1000, 60_000),
+  };
+  return json.access_token;
+}
+
 class Mem0MCPServer {
   private server: Server;
   private isCloudMode: boolean = false;
@@ -1024,18 +1061,98 @@ class Mem0MCPServer {
       };
     }
 
-    // Phase A skeleton: from is whitelisted but Graph POST is not implemented yet.
+    // Phase B: acquire Graph token (client_credentials), POST sendMail, audit log.
+    const tenantId = process.env.OUTBOUND_MAILER_TENANT_ID;
+    const clientId = process.env.OUTBOUND_MAILER_CLIENT_ID;
+    const clientSecret = process.env.OUTBOUND_MAILER_CLIENT_SECRET;
+    if (!tenantId || !clientId || !clientSecret) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        "send_mail: OUTBOUND_MAILER_TENANT_ID / CLIENT_ID / CLIENT_SECRET env vars are required on the server."
+      );
+    }
+
+    let token: string;
+    try {
+      token = await getOutboundGraphToken(tenantId, clientId, clientSecret);
+    } catch (e: any) {
+      console.error(`[send_mail] token_error from=${from}: ${e.message || e}`);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ ok: false, error: "graph_token_error", detail: String(e.message || e).slice(0, 300) }) },
+        ],
+      };
+    }
+
+    const recipientsToArr = to.map((addr) => ({ emailAddress: { address: addr } }));
+    const recipientsCcArr = Array.isArray(cc) && cc.length > 0
+      ? cc.map((addr) => ({ emailAddress: { address: addr } }))
+      : undefined;
+
+    const graphBody: any = {
+      message: {
+        subject,
+        body: { contentType: "HTML", content: bodyHtml },
+        toRecipients: recipientsToArr,
+      },
+      saveToSentItems: args.saveToSentItems !== false,
+    };
+    if (recipientsCcArr) graphBody.message.ccRecipients = recipientsCcArr;
+
+    const sendUrl = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(from)}/sendMail`;
+    const sentAt = new Date().toISOString();
+    const recipientsCount = to.length + (cc?.length ?? 0);
+
+    let graphResp: Response;
+    try {
+      graphResp = await fetch(sendUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(graphBody),
+      });
+    } catch (e: any) {
+      console.error(`[send_mail] network_error from=${from} subject="${subject}": ${e.message || e}`);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ ok: false, error: "graph_network_error", detail: String(e.message || e).slice(0, 300) }) },
+        ],
+      };
+    }
+
+    if (!graphResp.ok) {
+      let detail = "";
+      try { detail = await graphResp.text(); } catch { /* ignore */ }
+      console.error(`[send_mail] graph_error from=${from} status=${graphResp.status} subject="${subject}" recipients=${recipientsCount} detail=${detail.slice(0, 500)}`);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              ok: false,
+              error: "graph_error",
+              status: graphResp.status,
+              detail: detail.slice(0, 500),
+            }),
+          },
+        ],
+      };
+    }
+
+    console.log(`[send_mail] sent at=${sentAt} from=${from} subject="${subject}" recipients=${recipientsCount} status=${graphResp.status}`);
+
     return {
       content: [
         {
           type: "text",
           text: JSON.stringify({
-            ok: false,
-            error: "not_implemented_phase_a",
+            ok: true,
+            sentAt,
             from,
-            recipientsCount: to.length + (cc?.length ?? 0),
+            recipientsCount,
             subject,
-            hint: "Phase A skeleton only. Phase B (Graph POST sendMail) pending. See BRIEF_MAIL_TOOL_MCP_v1.md on SharePoint.",
           }),
         },
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -499,7 +499,7 @@ class Mem0MCPServer {
               properties: {
                 from: {
                   type: "string",
-                  description: "Adresse UPN de la boite expeditrice (ex: charli@pereneo.eu, paul.rudler@oseys.fr). Doit etre dans la whitelist FROM_WHITELIST sinon erreur from_not_whitelisted.",
+                  description: "Adresse UPN de la boite expeditrice. Convention durable: COMEX humains sur @groupeperenne.com (paul.rudler@, constantin.picoron@, olivier.rudler@), Charli sur @pereneo.eu, agents OSEYS pilotes sur @perennereseau.fr (david@, martin@, mila@), Alicia DG Prosperenne sur @prosperene.eu. JAMAIS @oseys.fr en from par defaut (obsolete post-rebrand, proxy lecture seulement). Doit etre dans la whitelist FROM_WHITELIST sinon erreur from_not_whitelisted (qui retournera la liste exacte des UPNs autorises).",
                 },
                 to: {
                   type: "array",
@@ -1046,6 +1046,7 @@ class Mem0MCPServer {
     }
 
     if (!whitelist.has(from.toLowerCase())) {
+      const allowed = Array.from(whitelist).sort();
       return {
         content: [
           {
@@ -1054,7 +1055,8 @@ class Mem0MCPServer {
               ok: false,
               error: "from_not_whitelisted",
               from,
-              hint: "The sender address is not in FROM_WHITELIST. Contact Paul to extend the whitelist if legitimate.",
+              allowedFrom: allowed,
+              hint: "Le 'from' fourni n'est pas dans la whitelist. Utilise une adresse de la liste 'allowedFrom' ci-dessus. Convention: COMEX humains sur @groupeperenne.com, Charli sur @pereneo.eu, agents OSEYS sur @perennereseau.fr, Alicia sur @prosperene.eu. Les adresses @oseys.fr sont obsoletes post-rebrand.",
             }),
           },
         ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,22 @@ interface Mem0DeleteToolArgs {
   orgId?: string;      // Organization identifier (for mem0 organization-level management)
 }
 
+// Tool send_mail — multi-mailbox outbound mail via Microsoft Graph.
+// See BRIEF_MAIL_TOOL_MCP_v1.md (SharePoint TECHNIQUE/CLAUDE/1. PERENEO/) for full design.
+// Env vars (required for Phase B implementation, not Phase A skeleton):
+//   OUTBOUND_MAILER_TENANT_ID    : Entra tenant id
+//   OUTBOUND_MAILER_CLIENT_ID    : App Reg appId (Pereneo Charli Outbound Mailer)
+//   OUTBOUND_MAILER_CLIENT_SECRET: client_credentials secret (Key Vault ref recommended)
+//   FROM_WHITELIST               : comma-separated UPNs (e.g. charli@pereneo.eu,paul.rudler@oseys.fr)
+interface SendMailToolArgs {
+  from: string;
+  to: string[];
+  cc?: string[];
+  subject: string;
+  bodyHtml: string;
+  saveToSentItems?: boolean;
+}
+
 // Message type for Mem0 API
 type Mem0Message = {
   role: "user" | "assistant" | "system";
@@ -438,6 +454,42 @@ class Mem0MCPServer {
               required: ["memoryId"],
             },
           },
+          {
+            name: "send_mail",
+            description: "Envoie un mail depuis une boite du tenant Pereneo via Microsoft Graph. La boite expeditrice (from) doit etre dans la whitelist FROM_WHITELIST (cote serveur). Charli redige le bodyHtml en respectant la DA Pereneo (skill local CLI ou knowledge file DAPERENNE_v1.md Project Charli). Pas de confirmation utilisateur bloquante cote tool: l'envoi se fait immediatement a l'appel.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                from: {
+                  type: "string",
+                  description: "Adresse UPN de la boite expeditrice (ex: charli@pereneo.eu, paul.rudler@oseys.fr). Doit etre dans la whitelist FROM_WHITELIST sinon erreur from_not_whitelisted.",
+                },
+                to: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "Destinataires principaux (au moins un).",
+                },
+                cc: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "Destinataires en copie (optionnel).",
+                },
+                subject: {
+                  type: "string",
+                  description: "Sujet du mail.",
+                },
+                bodyHtml: {
+                  type: "string",
+                  description: "Corps HTML du mail. Charli applique la DA Pereneo (palette, typo Inter, ton COMEX tutoiement / externe vouvoiement, signature contextualisee) en amont de l'appel.",
+                },
+                saveToSentItems: {
+                  type: "boolean",
+                  description: "Si true (defaut), le mail est enregistre dans les Elements envoyes de la boite from.",
+                },
+              },
+              required: ["from", "to", "subject", "bodyHtml"],
+            },
+          },
         ],
       };
     });
@@ -461,6 +513,9 @@ class Mem0MCPServer {
         } else if (name === "delete_memory") {
           const toolArgs = args as unknown as Mem0DeleteToolArgs;
           return await this.handleDeleteMemory(toolArgs);
+        } else if (name === "send_mail") {
+          const toolArgs = args as unknown as SendMailToolArgs;
+          return await this.handleSendMail(toolArgs);
         } else {
           throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
         }
@@ -905,6 +960,86 @@ class Mem0MCPServer {
     } else {
       throw new McpError(ErrorCode.InternalError, "No memory client is available");
     }
+  }
+
+  /**
+   * Handles sending a mail via Microsoft Graph sendMail.
+   *
+   * Phase A skeleton (commit initial): validates required fields, parses FROM_WHITELIST,
+   * checks `from` is whitelisted. Returns not_implemented on success path to signal that
+   * the Graph token + POST flow is not wired yet.
+   *
+   * Phase B (separate commit): acquire client_credentials token, POST /v1.0/users/{from}/sendMail,
+   * audit log (timestamp, from, to/cc counts, subject, caller identity from JWT), return
+   * { ok: true, sentAt, from, recipientsCount } or { ok: false, error }.
+   *
+   * Phase C (separate commit): ApplicationAccessPolicy via Exchange Online + smoke test plan.
+   *
+   * Mandate: Paul 21 May 2026 PM. Brief: BRIEF_MAIL_TOOL_MCP_v1.md (SharePoint TECHNIQUE/CLAUDE/1. PERENEO/).
+   */
+  private async handleSendMail(args: SendMailToolArgs): Promise<any> {
+    const { from, to, cc, subject, bodyHtml } = args;
+
+    if (!from || typeof from !== "string") {
+      throw new McpError(ErrorCode.InvalidParams, "send_mail: 'from' is required (UPN string)");
+    }
+    if (!Array.isArray(to) || to.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "send_mail: 'to' must be a non-empty array of UPN strings");
+    }
+    if (!subject || typeof subject !== "string") {
+      throw new McpError(ErrorCode.InvalidParams, "send_mail: 'subject' is required (string)");
+    }
+    if (!bodyHtml || typeof bodyHtml !== "string") {
+      throw new McpError(ErrorCode.InvalidParams, "send_mail: 'bodyHtml' is required (HTML string)");
+    }
+
+    const rawWhitelist = process.env.FROM_WHITELIST || "";
+    const whitelist = new Set(
+      rawWhitelist
+        .split(",")
+        .map((s) => s.trim().toLowerCase())
+        .filter((s) => s.length > 0)
+    );
+
+    if (whitelist.size === 0) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        "send_mail: FROM_WHITELIST env var is not configured on the server. Tool is unavailable."
+      );
+    }
+
+    if (!whitelist.has(from.toLowerCase())) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              ok: false,
+              error: "from_not_whitelisted",
+              from,
+              hint: "The sender address is not in FROM_WHITELIST. Contact Paul to extend the whitelist if legitimate.",
+            }),
+          },
+        ],
+      };
+    }
+
+    // Phase A skeleton: from is whitelisted but Graph POST is not implemented yet.
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            ok: false,
+            error: "not_implemented_phase_a",
+            from,
+            recipientsCount: to.length + (cc?.length ?? 0),
+            subject,
+            hint: "Phase A skeleton only. Phase B (Graph POST sendMail) pending. See BRIEF_MAIL_TOOL_MCP_v1.md on SharePoint.",
+          }),
+        },
+      ],
+    };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -702,48 +702,28 @@ class Mem0MCPServer {
         if (keywordSearch !== undefined) options.keyword_search = keywordSearch;
         if (filterMemories !== undefined) options.filter_memories = filterMemories;
 
-        // API call - try direct REST API approach first for better parameter support
+        // Always use direct REST API for search. The SDK mem0ai 2.x calls v2 which
+        // requires `filters` and silently returns empty if missing (BL-55 root cause,
+        // diagnosed 12 May 2026 PM). v1 endpoint accepts user_id flat, still supported.
         let results;
-        let usedDirectAPI = false;
-
-        // Always try direct REST API first when app_id or run_id are provided
-        if (finalAppId || sessionId) {
-          try {
-            const apiUrl = 'https://api.mem0.ai/v1/memories/search';
-            const requestBody = {
-              query: query,
-              ...options
-            };
-
-            const response = await fetch(apiUrl, {
-              method: 'POST',
-              headers: {
-                'Authorization': `Token ${process.env.MEM0_API_KEY}`,
-                'Content-Type': 'application/json'
-              },
-              body: JSON.stringify(requestBody)
-            });
-
-            if (!response.ok) {
-              const errorText = await response.text();
-              throw new Error(`Direct search API call failed: ${response.status} ${response.statusText} - ${errorText}`);
-            }
-
-            results = await response.json();
-            usedDirectAPI = true;
-          } catch (directError: any) {
-            // Fall through to SDK attempt
-          }
+        const apiUrl = 'https://api.mem0.ai/v1/memories/search/';
+        const requestBody = {
+          query: query,
+          ...options
+        };
+        const response = await fetch(apiUrl, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Token ${process.env.MEM0_API_KEY}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(requestBody)
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Mem0 search API call failed: ${response.status} ${response.statusText} - ${errorText}`);
         }
-
-        // Try SDK if direct API wasn't used or failed
-        if (!usedDirectAPI) {
-          try {
-            results = await this.cloudClient.search(query, options);
-          } catch (sdkError: any) {
-            throw sdkError;
-          }
-        }
+        results = await response.json();
 
         // Handle potential array or object result
         const resultsArray = Array.isArray(results) ? results : [results];
@@ -945,6 +925,7 @@ class Mem0MCPServer {
     const tenantId = process.env.ENTRA_TENANT_ID;
     const audience = process.env.ENTRA_AUDIENCE;            // identifierUri (advertised in /.well-known)
     const audienceGuid = process.env.ENTRA_AUDIENCE_GUID;   // appId GUID (Entra v2 emits this in aud claim)
+    const audienceExtra = process.env.ENTRA_AUDIENCE_EXTRA; // secondary identifierUri accepted in aud (transition / multi-domain)
     const resourceUrl = process.env.RESOURCE_URL;
     if (!tenantId || !audience || !resourceUrl) {
       process.stderr.write('FATAL: ENTRA_TENANT_ID, ENTRA_AUDIENCE, and RESOURCE_URL env vars are required in HTTP mode.\n');
@@ -953,7 +934,7 @@ class Mem0MCPServer {
     // Per Microsoft docs (entra/identity-platform/access-token-claims-reference): v2 tokens carry
     // aud = client ID GUID of the web API; v1 tokens carry aud = appID URI. We accept both for
     // robustness across delegated and client_credentials flows.
-    const acceptedAudiences: string[] = [audience, audienceGuid].filter((x): x is string => !!x);
+    const acceptedAudiences: string[] = [audience, audienceGuid, audienceExtra].filter((x): x is string => !!x);
     const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
     const jwksUri = `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
     const JWKS = createRemoteJWKSet(new URL(jwksUri), {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,14 +118,28 @@ interface Mem0DeleteToolArgs {
 //   OUTBOUND_MAILER_CLIENT_ID    : App Reg appId (Pereneo Charli Outbound Mailer)
 //   OUTBOUND_MAILER_CLIENT_SECRET: client_credentials secret (Key Vault ref recommended)
 //   FROM_WHITELIST               : comma-separated UPNs (e.g. charli@pereneo.eu,paul.rudler@oseys.fr)
+interface SendMailAttachment {
+  name: string;
+  contentType: string;
+  contentBytes: string; // base64-encoded file content
+}
+
 interface SendMailToolArgs {
   from: string;
   to: string[];
   cc?: string[];
+  bcc?: string[];
   subject: string;
   bodyHtml: string;
   saveToSentItems?: boolean;
+  attachments?: SendMailAttachment[];
 }
+
+// Microsoft Graph sendMail caps the total request payload (including base64-encoded
+// attachments) at ~4 MB. Base64 expands raw bytes by ~33%, so the practical raw cap
+// is ~3 MB total across all attachments before the JSON envelope itself adds weight.
+// Beyond that, /createUploadSession is required (not implemented here).
+const SEND_MAIL_ATTACHMENT_BASE64_LIMIT = 3_500_000; // ~3.5 MB of base64 chars total
 
 // Message type for Mem0 API
 type Mem0Message = {
@@ -511,6 +525,11 @@ class Mem0MCPServer {
                   items: { type: "string" },
                   description: "Destinataires en copie (optionnel).",
                 },
+                bcc: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "Destinataires en copie cachee (optionnel). Utile pour envoi multi-destinataires sans qu'ils se voient entre eux, ou pour s'auto-archiver une copie.",
+                },
                 subject: {
                   type: "string",
                   description: "Sujet du mail.",
@@ -522,6 +541,19 @@ class Mem0MCPServer {
                 saveToSentItems: {
                   type: "boolean",
                   description: "Si true (defaut), le mail est enregistre dans les Elements envoyes de la boite from.",
+                },
+                attachments: {
+                  type: "array",
+                  description: "Pieces jointes (optionnel). Limite cumulee ~3 MB de contenu brut (base64 expanse ~4 MB, plafond Graph sendMail). Au-dela, l'appel echouera avec attachment_too_large.",
+                  items: {
+                    type: "object",
+                    properties: {
+                      name: { type: "string", description: "Nom du fichier visible par le destinataire (ex. 'rapport.pdf')." },
+                      contentType: { type: "string", description: "MIME type (ex. 'application/pdf', 'image/png', 'text/csv')." },
+                      contentBytes: { type: "string", description: "Contenu binaire du fichier encode en base64 (chaine sans prefixe data:)." },
+                    },
+                    required: ["name", "contentType", "contentBytes"],
+                  },
                 },
               },
               required: ["from", "to", "subject", "bodyHtml"],
@@ -1015,7 +1047,7 @@ class Mem0MCPServer {
    * Mandate: Paul 21 May 2026 PM. Brief: BRIEF_MAIL_TOOL_MCP_v1.md (SharePoint TECHNIQUE/CLAUDE/1. PERENEO/).
    */
   private async handleSendMail(args: SendMailToolArgs): Promise<any> {
-    const { from, to, cc, subject, bodyHtml } = args;
+    const { from, to, cc, bcc, subject, bodyHtml, attachments } = args;
 
     if (!from || typeof from !== "string") {
       throw new McpError(ErrorCode.InvalidParams, "send_mail: 'from' is required (UPN string)");
@@ -1028,6 +1060,44 @@ class Mem0MCPServer {
     }
     if (!bodyHtml || typeof bodyHtml !== "string") {
       throw new McpError(ErrorCode.InvalidParams, "send_mail: 'bodyHtml' is required (HTML string)");
+    }
+    if (attachments !== undefined) {
+      if (!Array.isArray(attachments)) {
+        throw new McpError(ErrorCode.InvalidParams, "send_mail: 'attachments' must be an array when provided");
+      }
+      let totalBase64Length = 0;
+      for (let i = 0; i < attachments.length; i++) {
+        const att = attachments[i];
+        if (!att || typeof att !== "object") {
+          throw new McpError(ErrorCode.InvalidParams, `send_mail: attachments[${i}] must be an object`);
+        }
+        if (!att.name || typeof att.name !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, `send_mail: attachments[${i}].name is required (string)`);
+        }
+        if (!att.contentType || typeof att.contentType !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, `send_mail: attachments[${i}].contentType is required (string)`);
+        }
+        if (!att.contentBytes || typeof att.contentBytes !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, `send_mail: attachments[${i}].contentBytes is required (base64 string)`);
+        }
+        totalBase64Length += att.contentBytes.length;
+      }
+      if (totalBase64Length > SEND_MAIL_ATTACHMENT_BASE64_LIMIT) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                ok: false,
+                error: "attachment_too_large",
+                totalBase64Length,
+                limit: SEND_MAIL_ATTACHMENT_BASE64_LIMIT,
+                hint: "Microsoft Graph sendMail plafonne l'envoi inline (toutes pieces jointes confondues) a ~4 MB de payload encode. Reduis la taille des fichiers, ou splitte l'envoi en plusieurs mails. Pour des fichiers plus lourds il faudrait passer par /createUploadSession (non implemente).",
+              }),
+            },
+          ],
+        };
+      }
     }
 
     const rawWhitelist = process.env.FROM_WHITELIST || "";
@@ -1090,6 +1160,17 @@ class Mem0MCPServer {
     const recipientsCcArr = Array.isArray(cc) && cc.length > 0
       ? cc.map((addr) => ({ emailAddress: { address: addr } }))
       : undefined;
+    const recipientsBccArr = Array.isArray(bcc) && bcc.length > 0
+      ? bcc.map((addr) => ({ emailAddress: { address: addr } }))
+      : undefined;
+    const graphAttachments = Array.isArray(attachments) && attachments.length > 0
+      ? attachments.map((att) => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          name: att.name,
+          contentType: att.contentType,
+          contentBytes: att.contentBytes,
+        }))
+      : undefined;
 
     const graphBody: any = {
       message: {
@@ -1100,10 +1181,13 @@ class Mem0MCPServer {
       saveToSentItems: args.saveToSentItems !== false,
     };
     if (recipientsCcArr) graphBody.message.ccRecipients = recipientsCcArr;
+    if (recipientsBccArr) graphBody.message.bccRecipients = recipientsBccArr;
+    if (graphAttachments) graphBody.message.attachments = graphAttachments;
 
     const sendUrl = `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(from)}/sendMail`;
     const sentAt = new Date().toISOString();
-    const recipientsCount = to.length + (cc?.length ?? 0);
+    const recipientsCount = to.length + (cc?.length ?? 0) + (bcc?.length ?? 0);
+    const attachmentsCount = attachments?.length ?? 0;
 
     let graphResp: Response;
     try {
@@ -1143,7 +1227,7 @@ class Mem0MCPServer {
       };
     }
 
-    console.log(`[send_mail] sent at=${sentAt} from=${from} subject="${subject}" recipients=${recipientsCount} status=${graphResp.status}`);
+    console.log(`[send_mail] sent at=${sentAt} from=${from} subject="${subject}" recipients=${recipientsCount} attachments=${attachmentsCount} status=${graphResp.status}`);
 
     return {
       content: [
@@ -1154,6 +1238,7 @@ class Mem0MCPServer {
             sentAt,
             from,
             recipientsCount,
+            attachmentsCount,
             subject,
           }),
         },


### PR DESCRIPTION
## Summary

- Ajout de `bcc: string[]` et `attachments: [{name, contentType, contentBytes}]` au tool MCP `send_mail`
- Plafond cumulé pièces jointes : ~3.5 MB de base64 (≈ 2.6 MB de fichier brut) pour rester sous le cap Graph sendMail ~4 MB
- Au-delà du plafond → retour `attachment_too_large` avec hint (pas de `createUploadSession` implémenté)
- Audit log enrichi (`attachments=N`), retour `ok: true` expose `attachmentsCount`
- Bump version `0.6.4-pereneo.1` → `0.6.4-pereneo.2`

## Pourquoi

Avant ce patch, ni PJ ni BCC accessibles côté COMEX via Claude.ai PWA / Claude Desktop. Le seul moyen d'envoyer des PJ était passer par Charli en Claude Code CLI (Bash + curl manuel) — pas utilisable par Olivier ni Constantin.

## Test plan

- [x] Build TypeScript : `npm run build` passe sans erreur
- [ ] Test runtime sur staging Container App : envoi simple sans PJ (régression)
- [ ] Test runtime : envoi avec 1 PJ ~500 KB → vérifier réception côté boîte cible
- [ ] Test runtime : envoi avec PJ > 3.5 MB → vérifier retour `attachment_too_large`
- [ ] Test runtime : envoi avec BCC seul → vérifier réception côté BCC
- [ ] Test runtime : envoi combo `cc + bcc + 2 PJ` → vérifier composition Graph correcte

## Files

- `src/index.ts` — schema tool + handler `handleSendMail` étendus
- `CHANGELOG.md` — entrée `0.6.4-pereneo.2`
- `package.json` — bump version

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email sending now supports attachments and BCC recipients.
  * HTTP transport protocol added with session management.
  * OAuth 2.0 resource server authentication support.
  * Health check endpoints for server monitoring.

* **Bug Fixes**
  * Server returns proper HTTP 404 for invalid session identifiers.

* **Chores**
  * Package versioning and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->